### PR TITLE
Fix for paths containing spaces

### DIFF
--- a/TesseractOCR/TesseractOCR.php
+++ b/TesseractOCR/TesseractOCR.php
@@ -186,7 +186,7 @@ class TesseractOCR
      */
     protected function buildTesseractCommand()
     {
-        $command = "tesseract {$this->image}";
+        $command = "tesseract \"{$this->image}\"";
 
         if ($this->language) {
             $command.= " -l {$this->language}";


### PR DESCRIPTION
When using a path that contains spaces execution fails. Therefor I included quotes to fix this issue.
