### PR TITLE
Update TesseractOCR.php

### DIFF
--- a/TesseractOCR/TesseractOCR.php
+++ b/TesseractOCR/TesseractOCR.php
@@ -205,7 +205,7 @@ class TesseractOCR
      */
     protected function buildTesseractCommand()
     {
-        $command = "tesseract \"{$this->image}\"";
+        $command = "tesseract '{$this->image}'";
 
         if ($this->language) {
             $command.= " -l {$this->language}";


### PR DESCRIPTION
Files with $ in name doesn't work.

If the target file name has $ in it, it fails. Fix is to use single quote instead of double around the file name.