### PR TITLE
Manage spaces on Windows Path

### DIFF
--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -91,9 +91,9 @@ class TesseractOCR
      */
     public function executable($executable)
     {
-        // Manage windows path on C:\Program Files\... (path with spaces)
-        if(strpos($executable, ' ') !== FALSE) {
-            $this->executable = "$executable";
+        // Manage windows path on C:\Program Files\... (path with spaces) && prevent for already escaped path
+        if (strpos($executable, ' ') !== FALSE && strpos($executable, '"') === FALSE) {
+            $this->executable = '"' . $executable . '"';
         } else {
             // Default case (linux)
             $this->executable = $executable;

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -91,7 +91,13 @@ class TesseractOCR
      */
     public function executable($executable)
     {
-        $this->executable = $executable;
+        // Manage windows path on C:\Program Files\... (path with spaces)
+        if(strpos($executable, ' ') !== FALSE) {
+            $this->executable = "$executable";
+        } else {
+            // Default case (linux)
+            $this->executable = $executable;
+        }
         return $this;
     }
 


### PR DESCRIPTION
On Windows, the tesseract tools should be installed on C:\Program Files (x86)\Tesseract-OCR\tesseract.exe

if you just set 
```php
$myOCR->executable('C:\Program Files (x86)\Tesseract-OCR\tesseract.exe');
```
it will result on no results because the generated command line is something like 
```batch
C:\Users\Anael>C:\Program Files (x86)\Tesseract-OCR\tesseract.exe "C:\xampp\htdocs\root-me\image_ocr.png" stdout
'C:\Program' n’est pas reconnu en tant que commande interne ou externe, un programme exécutable ou un fichier de commandes.
```

This PR add the ability to detect spaces on the path (on Windows so), and add double quotes against tesseract path (if not already defined by the user).
So, the output should now be
```batch
C:\Users\Anael>"C:\Program Files (x86)\Tesseract-OCR\tesseract.exe" "C:\xampp\htdocs\root-me\image_ocr.png" stdout
```
which run fine