### PR TITLE
More flexible way to set languages

### DIFF
--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -134,12 +134,16 @@ class TesseractOCR
     /**
      * Sets the language(s).
      *
-     * @param string ...$languages
+     * @param string|array ...$languages
      * @return TesseractOCR
      */
     public function lang()
     {
-        $this->languages = func_get_args();
+        if (1 == func_num_args() && is_array(func_get_arg(0))) {
+            $this->languages = func_get_arg(0);
+        } else {
+            $this->languages = func_get_args();
+        }
         return $this;
     }
 

--- a/tests/UnitTests.php
+++ b/tests/UnitTests.php
@@ -155,7 +155,6 @@ class UnitTests extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
-
     /**
      * When a page segmentation mode is provided, the '-psm' option should be
      * appended to the command with its correspondent value.

--- a/tests/UnitTests.php
+++ b/tests/UnitTests.php
@@ -139,6 +139,24 @@ class UnitTests extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Even more sugar when providing multiple languages as an array, because passing them all
+     * as dynamic parameters is not very comfortable when you want to assign them dynamically:
+     *
+     *     (new TesseractOCR('img'))->lang('eng', 'deu', 'jpn');
+     */
+    public function testLanguageArrayOptionForMultipleLanguages()
+    {
+        $expected = "tesseract 'image.png' stdout -l eng+deu+jpn";
+
+        $actual = (new WrapTesseractOCR('image.png'))
+            ->lang(array('eng', 'deu', 'jpn'))
+            ->buildCommand();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
+    /**
      * When a page segmentation mode is provided, the '-psm' option should be
      * appended to the command with its correspondent value.
      */


### PR DESCRIPTION
I currently have the problem that I want to configure possible languages dynamically in a Symfony Framework project.

To make this task easier also for others, I think its a nice thing that you can set the languages just as an array but also keeping the old behavior (BC).

Now you can set the languages like follow:

`$t->lang('eng+deu+jpn');`
`$t->lang('eng', 'deu', 'jpn');`
`$t->lang(array('eng', 'deu', 'jpn'));`