### PR TITLE
Add OEM (OCR Engine Mode)

### DIFF
--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -55,6 +55,13 @@ class TesseractOCR
     private $psm;
 
     /**
+     * OCR Engine Mode value.
+     *
+     * @var integer
+     */
+    private $oem;
+
+    /**
      * List of tesseract configuration variables.
      *
      * @var array
@@ -163,6 +170,18 @@ class TesseractOCR
     }
 
     /**
+     * Sets the OCR Engine Mode
+     *
+     * @param integer $oem
+     * @return TesseractOCR
+     */
+    public function oem($oem)
+    {
+        $this->oem = $oem;
+        return $this;
+    }
+
+    /**
      * Sets a tesseract configuration value.
      *
      * @param string $key
@@ -220,6 +239,7 @@ class TesseractOCR
             .$this->buildUserPatternsParam()
             .$this->buildLanguagesParam()
             .$this->buildPsmParam()
+            .$this->buildOemParam()
             .$this->buildConfigurationsParam()
             .$this->buildQuietMode();
     }
@@ -277,6 +297,17 @@ class TesseractOCR
     private function buildPsmParam()
     {
         return is_null($this->psm) ? '' : ' -psm '.$this->psm;
+    }
+
+    /**
+     * If a OCR Engine Mode is defined, return the correspondent command
+     * line argument to the tesseract command.
+     *
+     * @return string
+     */
+    private function buildOemParam()
+    {
+        return is_null($this->oem) ? '' : ' --oem '.$this->oem;
     }
 
     /**


### PR DESCRIPTION
I had issues with LSTM and Tesseract-OCR 4.
Parameters I need does not work with LSTM enabled (example: tessedit_char_blacklist and tessedit_char_whitelist)