### PR TITLE
make quiet mode actually quiet

### DIFF
--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -304,6 +304,6 @@ class TesseractOCR
      */
     private function buildQuietMode()
     {
-        return $this->statusQuietMode ? ' quiet' : '';
+        return $this->statusQuietMode ? ' quiet 2>/dev/null' : '';
     }
 }


### PR DESCRIPTION
Error/warning messages from tesseract are still being displayed when using quiet mode. Redirecting stderr to /dev/null fixes this.

Example of warning messages when running unit tests:
![image](https://user-images.githubusercontent.com/7202674/31853464-f1925f4e-b688-11e7-9f2e-52159b7bac82.png)
