### PR TITLE
add suppress errors mode

### DIFF
--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -69,6 +69,13 @@ class TesseractOCR
     private $statusQuietMode = false;
 
     /**
+     * If true, all warnings and errors from tesseract will be suppressed.
+     *
+     * @var bool
+     */
+    private $suppressErrorsMode = false;
+
+    /**
      * Class constructor.
      *
      * @param string $image
@@ -201,9 +208,21 @@ class TesseractOCR
      * @param bool $status
      * @return $this
      */
-    public function quietMode($status)
+    public function quietMode($status = true)
     {
         $this->statusQuietMode = boolval($status);
+        return $this;
+    }
+
+    /**
+     * Change suppress errors mode state.
+     *
+     * @param bool $status
+     * @return $this
+     */
+    public function suppressErrors($status = true)
+    {
+        $this->suppressErrorsMode = boolval($status);
         return $this;
     }
 
@@ -221,7 +240,8 @@ class TesseractOCR
             .$this->buildLanguagesParam()
             .$this->buildPsmParam()
             .$this->buildConfigurationsParam()
-            .$this->buildQuietMode();
+            .$this->buildQuietMode()
+            .$this->buildSuppressErrorsMode();
     }
 
     /**
@@ -305,5 +325,16 @@ class TesseractOCR
     private function buildQuietMode()
     {
         return $this->statusQuietMode ? ' quiet' : '';
+    }
+
+    /**
+     * If suppress errors mode is defined, redirect all stderr output from the
+     * tesseract command to /dev/null.
+     *
+     * @return string
+     */
+    private function buildSuppressErrorsMode()
+    {
+        return $this->suppressErrorsMode ? ' 2>/dev/null' : '';
     }
 }

--- a/tests/FunctionalTests.php
+++ b/tests/FunctionalTests.php
@@ -12,7 +12,9 @@ class FunctionalTests extends PHPUnit_Framework_TestCase
     {
         $expected = "The quick brown fox\njumps over the lazy\ndog.";
 
-        $actual = (new TesseractOCR(__DIR__.'/text.png'))->run();
+        $actual = (new TesseractOCR(__DIR__.'/text.png'))
+            ->suppressErrors()
+            ->run();
 
         $this->assertEquals($expected, $actual);
     }
@@ -25,6 +27,7 @@ class FunctionalTests extends PHPUnit_Framework_TestCase
         $expected = "Issue found by\n@crimsonvspurple";
 
         $actual = (new TesseractOCR(__DIR__.'/img name$with@special#chars.png'))
+            ->suppressErrors()
             ->run();
 
         $this->assertEquals($expected, $actual);

--- a/tests/UnitTests.php
+++ b/tests/UnitTests.php
@@ -199,4 +199,16 @@ class UnitTests extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testSuppressErrorsMode()
+    {
+        $expected = "tesseract 'image.png' stdout quiet 2>/dev/null";
+
+        $actual = (new TesseractOCR('image.png'))
+            ->quietMode(true)
+            ->suppressErrors()
+            ->buildCommand();
+
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
The new suppress errors mode redirects stdout to /dev/null, suppressing all warning and error messages.

I added this because tesseract writes warnings to my console that i can safely ignore. (warning such as `Error in pixGenHalftoneMask: pix too small: w = 160, h = 74`).

This is what my console used to look like when using this package:
![image](https://user-images.githubusercontent.com/7202674/32135857-390637b0-bc06-11e7-9cbf-b7adc301ebd3.png)


This is what it looks like with the suppress errors mode enabled:
![image](https://user-images.githubusercontent.com/7202674/32135864-4cc3f5c6-bc06-11e7-93eb-89e09952eb3a.png)


