### PR TITLE
[fix] array to string conversion error

### DIFF
--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -46,7 +46,7 @@ class TesseractOCR
 		if ($this->isConfigFile($method)) return $this->configFile($method);
 		if ($this->isOption($method)) {
 			$option = $this->getOptionClassName().'::'.$method;
-			$this->command->options[] = call_user_func($option, $args);
+			$this->command->options[] = call_user_func_array($option, $args);
 			return $this;
 		}
 		$this->command->options[] = Option::config($method, $args[0]);


### PR DESCRIPTION
When you pass $args to call_user_func() called method will receive an array as the first argument. You should use call_user_func_array() instead.