### PR TITLE
implemented ability to limit number of threads used by tesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,17 @@ echo (new TesseractOCR('img.png'))
 
 __More info:__ <https://github.com/tesseract-ocr/tesseract/wiki/ControlParams>
 
+### Thread-limit
+
+Sometimes, it may be useful to limit the number of threads that tesseract is
+allowed to use (e.g. in [this case](https://github.com/tesseract-ocr/tesseract/issues/898)).
+Set the maxmium number of threads as param for the run()-function:
+
+```php
+echo (new TesseractOCR('img.png'))
+    ->run(1);
+```
+
 ## Where to get help
 
 Join the chat at <https://gitter.im/thiagoalessio/tesseract-ocr-for-php>

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -12,14 +12,13 @@ class TesseractOCR
 		$this->command = $command ?: new Command($image);
 	}
 
-	public function run($thread_limit=0)
+	public function run($threadLimit=0)
 	{
-        if ($thread_limit > 0) {
-            $cmd = "OMP_THREAD_LIMIT=" . $thread_limit . " {$this->command}";
-        } else {
-            $cmd = "{$this->command}";
+        $cmd = "{$this->command}";
+        if ($threadLimit > 0) {
+            $cmd = "OMP_THREAD_LIMIT=" . $threadLimit . " " . $cmd;
         }
-		exec($cmd, $output);
+        exec($cmd, $output);
 		return trim(join(PHP_EOL, $output));
 	}
 

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -12,9 +12,14 @@ class TesseractOCR
 		$this->command = $command ?: new Command($image);
 	}
 
-	public function run()
+	public function run($thread_limit=0)
 	{
-		exec("{$this->command}", $output);
+        if ($thread_limit > 0) {
+            $cmd = "OMP_THREAD_LIMIT=" . $thread_limit . " {$this->command}";
+        } else {
+            $cmd = "{$this->command}";
+        }
+		exec($cmd, $output);
 		return trim(join(PHP_EOL, $output));
 	}
 

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -14,11 +14,11 @@ class TesseractOCR
 
 	public function run($threadLimit=0)
 	{
-        $cmd = "{$this->command}";
-        if ($threadLimit > 0) {
-            $cmd = "OMP_THREAD_LIMIT=" . $threadLimit . " " . $cmd;
-        }
-        exec($cmd, $output);
+		$cmd = "{$this->command}";
+		if ($threadLimit > 0) {
+			$cmd = "OMP_THREAD_LIMIT=" . $threadLimit . " " . $cmd;
+		}
+		exec($cmd, $output);
 		return trim(join(PHP_EOL, $output));
 	}
 


### PR DESCRIPTION
Running multiple content-extraction-jobs in parallel on one machine leads to an enormous increase of execution time (see https://github.com/tesseract-ocr/tesseract/issues/1019). One solution is to limit the number of threads usable by tesseract. If you have 4 cores and limit the number of threads used by tesseract to two, two parallel extractions are working fine.
Sadly, there is no built-in option for tesseract to limit the number of threads. But it's possible to do so with the OMP_THREAD_LIMIT-command.

Grüße nach Berlin!