### PR TITLE
Add friendly error messages

### DIFF
--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -1,0 +1,61 @@
+<?php namespace thiagoalessio\TesseractOCR;
+
+class ImageNotFoundException extends \Exception {}
+class TesseractNotFoundException extends \Exception {}
+class UnsuccessfulCommandException extends \Exception {}
+
+class FriendlyErrors
+{
+	public static function checkImagePath($image)
+	{
+		if (is_null($image) || file_exists($image)) return;
+
+		$currentDir = __DIR__;
+		$msg = array();
+		$msg[] = "Error! The image \"$image\" was not found.";
+		$msg[] = '';
+		$msg[] = "The current __DIR__ is $currentDir";
+		$msg = join(PHP_EOL, $msg);
+
+		throw new ImageNotFoundException($msg);
+	}
+
+	public static function checkTesseractPresence($executable)
+	{
+		$cmd = stristr(PHP_OS, 'win') ? "where $executable" : "type $executable";
+		exec("$cmd 2>&1", $_, $exitCode);
+
+		if ($exitCode == 0) return;
+
+		$currentPath = getenv('PATH');
+		$msg = array();
+		$msg[] = "Error! The command \"$executable\" was not found.";
+		$msg[] = '';
+		$msg[] = 'Make sure you have Tesseract OCR installed on your system:';
+		$msg[] = 'https://github.com/tesseract-ocr/tesseract';
+		$msg[] = '';
+		$msg[] = "The current \$PATH is $currentPath";
+		$msg = join(PHP_EOL, $msg);
+
+		throw new TesseractNotFoundException($msg);
+	}
+
+	public static function checkCommandExecution($command, $stdout)
+	{
+		$file = "{$command->getOutputFile()}.txt";
+
+		if (file_exists($file) && filesize($file) > 0) return;
+
+		$msg = array();
+		$msg[] = 'Error! The command did not produce any output.';
+		$msg[] = '';
+		$msg[] = 'Generated command:';
+		$msg[] = "$command";
+		$msg[] = '';
+		$msg[] = 'Returned message:';
+		$msg = array_merge($msg, $stdout);
+		$msg = join(PHP_EOL, $msg);
+
+		throw new UnsuccessfulCommandException($msg);
+	}
+}

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -2,6 +2,7 @@
 
 use thiagoalessio\TesseractOCR\Command;
 use thiagoalessio\TesseractOCR\Option;
+use thiagoalessio\TesseractOCR\FriendlyErrors;
 
 class TesseractOCR
 {
@@ -9,12 +10,18 @@ class TesseractOCR
 
 	public function __construct($image, $command=null)
 	{
+		FriendlyErrors::checkImagePath($image);
 		$this->command = $command ?: new Command($image);
 	}
 
 	public function run()
 	{
-		exec("{$this->command} 2>&1");
+		FriendlyErrors::checkTesseractPresence($this->command->executable);
+
+		exec("{$this->command} 2>&1", $stdout);
+
+		FriendlyErrors::checkCommandExecution($this->command, $stdout);
+
 		$text = file_get_contents("{$this->command->getOutputFile()}.txt");
 		return trim($text, " \t\n\r\0\x0A\x0B\x0C");
 	}

--- a/tests/EndToEnd/FriendlyErrors.php
+++ b/tests/EndToEnd/FriendlyErrors.php
@@ -1,0 +1,102 @@
+<?php namespace thiagoalessio\TesseractOCR\Tests\EndToEnd;
+
+use thiagoalessio\TesseractOCR\Tests\Common\TestCase;
+use thiagoalessio\TesseractOCR\TesseractOCR;
+use thiagoalessio\TesseractOCR\Tests\Unit\TestableCommand;
+
+use thiagoalessio\TesseractOCR\ImageNotFoundException;
+use thiagoalessio\TesseractOCR\TesseractNotFoundException;
+use thiagoalessio\TesseractOCR\UnsuccessfulCommandException;
+
+class FriendlyErrors extends TestCase
+{
+	public function testImageNotFound()
+	{
+		$currentDir = realpath(
+			join(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'src'])
+		);
+
+		$expected = array();
+		$expected[] = 'Error! The image "/invalid/image.png" was not found.';
+		$expected[] = '';
+		$expected[] = "The current __DIR__ is $currentDir";
+		$expected = join(PHP_EOL, $expected);
+
+		try {
+			(new TesseractOCR('/invalid/image.png'))->run();
+			throw new \Exception('ImageNotFoundException not thrown');
+		} catch (\Exception $e) {
+			$this->assertEquals($expected, $e->getMessage());
+		}
+	}
+
+	public function testExecutableNotFound()
+	{
+		$currentPath = getenv('PATH');
+
+		$expected = array();
+		$expected[] = 'Error! The command "/nowhere/tesseract" was not found.';
+		$expected[] = '';
+		$expected[] = 'Make sure you have Tesseract OCR installed on your system:';
+		$expected[] = 'https://github.com/tesseract-ocr/tesseract';
+		$expected[] = '';
+		$expected[] = "The current \$PATH is $currentPath";
+		$expected = join(PHP_EOL, $expected);
+
+		try {
+			(new TesseractOCR('./tests/EndToEnd/images/text.png'))
+				->executable('/nowhere/tesseract')
+				->run();
+			throw new \Exception('TesseractNotFoundException not thrown');
+		} catch (TesseractNotFoundException $e) {
+			$this->assertEquals($expected, $e->getMessage());
+		}
+	}
+
+	public function testUnsuccessfulCommand()
+	{
+		$expected = array();
+		$expected[] = 'Error! The command did not produce any output.';
+		$expected[] = '';
+		$expected[] = 'Generated command:';
+		$expected[] = '"tesseract" "./tests/EndToEnd/images/not-an-image.txt" tmpfile quiet';
+		$expected[] = '';
+		$expected[] = 'Returned message:';
+		if ($this->isVersion('3.04.01')) {
+			$expected[] = 'Tesseract Open Source OCR Engine v3.04.01 with Leptonica';
+		}
+		if ($this->isVersion('3.03')) {
+			$expected[] = 'Tesseract Open Source OCR Engine v3.03 with Leptonica';
+			$expected[] = 'Error in pixReadStream: Unknown format: no pix returned';
+			$expected[] = 'Error in pixRead: pix not read';
+			$expected[] = 'Error in pixGetInputFormat: pix not defined';
+		}
+		if ($this->isVersion('3.05.00dev')) {
+			$expected[] = 'Tesseract Open Source OCR Engine v3.05.00dev with Leptonica';
+			$expected[] = 'read_params_file: Can\'t open quiet';
+			$expected[] = 'Image file not an image cannot be read!';
+			$expected[] = 'Error during processing.';
+		} else {
+			$expected[] = 'Error in fopenReadStream: file not found';
+			$expected[] = 'Error in pixRead: image file not found: not an image';
+			$expected[] = 'Error during processing.';
+		}
+		$expected = join(PHP_EOL, $expected);
+
+		$cmd = new TestableCommand('./tests/EndToEnd/images/not-an-image.txt');
+		try {
+			(new TesseractOCR(null, $cmd))
+				->quiet()
+				->run();
+			throw new \Exception('UnsuccessfulCommandException not thrown');
+		} catch (UnsuccessfulCommandException $e) {
+			$this->assertEquals($expected, $e->getMessage());
+		}
+	}
+
+	protected function isVersion($version)
+	{
+		exec('tesseract --version 2>&1', $output);
+		return $output[0] == "tesseract $version";
+	}
+}

--- a/tests/EndToEnd/images/not-an-image.txt
+++ b/tests/EndToEnd/images/not-an-image.txt
@@ -1,0 +1,1 @@
+not an image


### PR DESCRIPTION
Provide useful debugging information to users to enable them to figure out
issues on their environments by themselves, as an attempt to decrease the
amount of support required on Gitter and the creation of GitHub issues.