### PR TITLE
Allow delayed setting of image to be recognized

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ of breaking CAPTCHAs, so please take a look at this comment:
 
 ## API
 
+### image
+
+Define the path of an image to be recognized by `tesseract`.
+
+```php
+$ocr = new TesseractOCR();
+$ocr->image('/path/to/image.png');
+$ocr->run();
+```
+
 ### executable
 
 Define a custom location of the `tesseract` executable,

--- a/src/Command.php
+++ b/src/Command.php
@@ -6,10 +6,10 @@ class Command
 	public $options = [];
 	public $configFile;
 	public $threadLimit;
-	private $image;
+	public $image;
 	private $outputFile;
 
-	public function __construct($image)
+	public function __construct($image=null)
 	{
 		$this->image = $image;
 	}

--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -8,7 +8,7 @@ class FriendlyErrors
 {
 	public static function checkImagePath($image)
 	{
-		if (is_null($image) || file_exists($image)) return;
+		if (file_exists($image)) return;
 
 		$currentDir = __DIR__;
 		$msg = array();

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -8,15 +8,16 @@ class TesseractOCR
 {
 	public $command;
 
-	public function __construct($image, $command=null)
+	public function __construct($image=null, $command=null)
 	{
-		FriendlyErrors::checkImagePath($image);
-		$this->command = $command ?: new Command($image);
+		$this->command = $command ?: new Command;
+		$this->image("$image");
 	}
 
 	public function run()
 	{
 		FriendlyErrors::checkTesseractPresence($this->command->executable);
+		FriendlyErrors::checkImagePath($this->command->image);
 
 		exec("{$this->command} 2>&1", $stdout);
 
@@ -24,6 +25,12 @@ class TesseractOCR
 
 		$text = file_get_contents("{$this->command->getOutputFile()}.txt");
 		return trim($text, " \t\n\r\0\x0A\x0B\x0C");
+	}
+
+	public function image($image)
+	{
+		$this->command->image = $image;
+		return $this;
 	}
 
 	public function executable($executable)

--- a/tests/EndToEnd/FriendlyErrors.php
+++ b/tests/EndToEnd/FriendlyErrors.php
@@ -104,9 +104,9 @@ class FriendlyErrors extends TestCase
 		}
 		$expected = join(PHP_EOL, $expected);
 
-		$cmd = new TestableCommand('./tests/EndToEnd/images/not-an-image.txt');
+		$cmd = new TestableCommand();
 		try {
-			(new TesseractOCR(null, $cmd))
+			(new TesseractOCR('./tests/EndToEnd/images/not-an-image.txt', $cmd))
 				->quiet()
 				->run();
 			throw new \Exception('UnsuccessfulCommandException not thrown');

--- a/tests/Unit/TesseractOCRTest.php
+++ b/tests/Unit/TesseractOCRTest.php
@@ -8,13 +8,24 @@ class TesseractOCRTest extends TestCase
 {
 	public function beforeEach()
 	{
-		$this->tess = new TesseractOCR(null, new TestableCommand('image.png'));
+		$this->tess = new TesseractOCR('image.png', new TestableCommand());
 	}
 
 	public function testSimplestUsage()
 	{
 		$expected = '"tesseract" "image.png" tmpfile';
 		$actual = $this->tess->command;
+		$this->assertEquals("$expected", "$actual");
+	}
+
+	public function testDelayedSettingOfImagePath()
+	{
+		$expected = '"tesseract" "image.png" tmpfile';
+
+		$ocr = new TesseractOCR(null, new TestableCommand());
+		$ocr->image('image.png');
+		$actual = $ocr->command;
+
 		$this->assertEquals("$expected", "$actual");
 	}
 

--- a/tests/Unit/TestableCommand.php
+++ b/tests/Unit/TestableCommand.php
@@ -4,7 +4,7 @@ use thiagoalessio\TesseractOCR\Command;
 
 class TestableCommand extends Command
 {
-	public function __construct($image, $version='3.05')
+	public function __construct($image=null, $version='3.05')
 	{
 		parent::__construct($image);
 		$this->version = $version;


### PR DESCRIPTION
There are some use cases of this library in which the user is not able to define the image path during the instantiation of `TesseractOCR`. ( For example on issue #134 )