### PR TITLE
Fix: OCR command failing when temp_dir contains any spaces

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -24,7 +24,7 @@ class Command
 		if ($this->threadLimit) $cmd[] = "OMP_THREAD_LIMIT={$this->threadLimit}";
 		$cmd[] = self::escape($this->executable);
 		$cmd[] = self::escape($this->image);
-		$cmd[] = $this->getOutputFile();
+		$cmd[] = self::escape($this->getOutputFile());
 
 		$version = $this->getTesseractVersion();
 

--- a/src/Command.php
+++ b/src/Command.php
@@ -24,7 +24,7 @@ class Command
 		if ($this->threadLimit) $cmd[] = "OMP_THREAD_LIMIT={$this->threadLimit}";
 		$cmd[] = self::escape($this->executable);
 		$cmd[] = self::escape($this->image);
-		$cmd[] = self::escape($this->getOutputFile());
+		$cmd[] = self::escape($this->getOutputFile(false));
 
 		$version = $this->getTesseractVersion();
 
@@ -36,17 +36,14 @@ class Command
 		return join(' ', $cmd);
 	}
 
-	public function getOutputFile()
+	public function getOutputFile($withExt=true)
 	{
 		if (!$this->outputFile) $this->outputFile = tempnam($this->getTempDir(), 'ocr');
-		return $this->outputFile;
-	}
+		if (!$withExt) return $this->outputFile;
 
-	public function getOutputFileWithExt()
-	{
 		$hasCustomExt = ['hocr', 'tsv', 'pdf'];
 		$ext = in_array($this->configFile, $hasCustomExt) ? $this->configFile : 'txt';
-		return "{$this->getOutputFile()}.{$ext}";
+		return "{$this->outputFile}.{$ext}";
 	}
 
 	public function getTempDir()

--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -46,7 +46,7 @@ class FriendlyErrors
 
 	public static function checkCommandExecution($command, $stdout)
 	{
-		$file = $command->getOutputFileWithExt();
+		$file = $command->getOutputFile();
 
 		if (file_exists($file) && filesize($file) > 0) return;
 

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -23,7 +23,7 @@ class TesseractOCR
 
 		FriendlyErrors::checkCommandExecution($this->command, $stdout);
 
-		$text = file_get_contents($this->command->getOutputFileWithExt());
+		$text = file_get_contents($this->command->getOutputFile());
 		$this->cleanTempFiles();
 		return trim($text, " \t\n\r\0\x0A\x0B\x0C");
 	}
@@ -109,7 +109,7 @@ class TesseractOCR
 
 	private function cleanTempFiles()
 	{
-		unlink($this->command->getOutputFile());
-		unlink($this->command->getOutputFileWithExt());
+		unlink($this->command->getOutputFile(false));
+		unlink($this->command->getOutputFile(true));
 	}
 }

--- a/tests/EndToEnd/FriendlyErrors.php
+++ b/tests/EndToEnd/FriendlyErrors.php
@@ -59,7 +59,7 @@ class FriendlyErrors extends TestCase
 		$expected[] = 'Error! The command did not produce any output.';
 		$expected[] = '';
 		$expected[] = 'Generated command:';
-		$expected[] = '"tesseract" "./tests/EndToEnd/images/not-an-image.txt" tmpfile quiet';
+		$expected[] = '"tesseract" "./tests/EndToEnd/images/not-an-image.txt" "tmpfile" quiet';
 		$expected[] = '';
 		$expected[] = 'Returned message:';
 

--- a/tests/Unit/CommandTest.php
+++ b/tests/Unit/CommandTest.php
@@ -24,7 +24,7 @@ class CommandTest extends TestCase
 	{
 		$cmd = new TestableCommand('image.png');
 
-		$expected = '"tesseract" "image.png" tmpfile';
+		$expected = '"tesseract" "image.png" "tmpfile"';
 		$this->assertEquals("$expected", "$cmd");
 	}
 
@@ -33,7 +33,7 @@ class CommandTest extends TestCase
 		$cmd = new TestableCommand('image.png');
 		$cmd->options[] = Option::lang('eng');
 
-		$expected = '"tesseract" "image.png" tmpfile -l eng';
+		$expected = '"tesseract" "image.png" "tmpfile" -l eng';
 		$this->assertEquals("$expected", "$cmd");
 	}
 
@@ -42,7 +42,7 @@ class CommandTest extends TestCase
 		$cmd = new TestableCommand('image.png');
 		$cmd->configFile = 'hocr';
 
-		$expected = '"tesseract" "image.png" tmpfile hocr';
+		$expected = '"tesseract" "image.png" "tmpfile" hocr';
 		$this->assertEquals("$expected", "$cmd");
 	}
 
@@ -61,7 +61,7 @@ class CommandTest extends TestCase
 		$cmd = new TestableCommand('image.png');
 		$cmd->threadLimit = 2;
 
-		$expected = 'OMP_THREAD_LIMIT=2 "tesseract" "image.png" tmpfile';
+		$expected = 'OMP_THREAD_LIMIT=2 "tesseract" "image.png" "tmpfile"';
 		$this->assertEquals("$expected", "$cmd");
 	}
 
@@ -69,7 +69,7 @@ class CommandTest extends TestCase
 	{
 		$cmd = new TestableCommand('$@ ! ? "#\'.png');
 
-		$expected = '"tesseract" "\$@ ! ? \\"#\'.png" tmpfile';
+		$expected = '"tesseract" "\$@ ! ? \\"#\'.png" "tmpfile"';
 		$this->assertEquals("$expected", "$cmd");
 	}
 }

--- a/tests/Unit/OutputFileTest.php
+++ b/tests/Unit/OutputFileTest.php
@@ -15,7 +15,7 @@ class OutputFileTest extends TestCase
 		foreach (['digits', 'quiet', 'txt', 'anything', 'else'] as $ext) {
 			$this->cmd->configFile = $ext;
 			$expected = "/path/to/output/file.txt";
-			$this->assertEquals($expected, $this->cmd->getOutputFileWithExt());
+			$this->assertEquals($expected, $this->cmd->getOutputFile());
 		}
 	}
 
@@ -23,20 +23,20 @@ class OutputFileTest extends TestCase
 	{
 		$this->cmd->configFile = 'hocr';
 		$expected = '/path/to/output/file.hocr';
-		$this->assertEquals($expected, $this->cmd->getOutputFileWithExt());
+		$this->assertEquals($expected, $this->cmd->getOutputFile());
 	}
 
 	public function testTsv()
 	{
 		$this->cmd->configFile = 'tsv';
 		$expected = '/path/to/output/file.tsv';
-		$this->assertEquals($expected, $this->cmd->getOutputFileWithExt());
+		$this->assertEquals($expected, $this->cmd->getOutputFile());
 	}
 
 	public function testPdf()
 	{
 		$this->cmd->configFile = 'pdf';
 		$expected = '/path/to/output/file.pdf';
-		$this->assertEquals($expected, $this->cmd->getOutputFileWithExt());
+		$this->assertEquals($expected, $this->cmd->getOutputFile());
 	}
 }

--- a/tests/Unit/TesseractOCRTest.php
+++ b/tests/Unit/TesseractOCRTest.php
@@ -27,14 +27,14 @@ class TesseractOCRTest extends TestCase
 
 	public function testSimplestUsage()
 	{
-		$expected = '"tesseract" "image.png" tmpfile';
+		$expected = '"tesseract" "image.png" "tmpfile"';
 		$actual = $this->tess->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testDelayedSettingOfImagePath()
 	{
-		$expected = '"tesseract" "image.png" tmpfile';
+		$expected = '"tesseract" "image.png" "tmpfile"';
 
 		$ocr = new TesseractOCR(null, new TestableCommand());
 		$ocr->image('image.png');
@@ -45,56 +45,56 @@ class TesseractOCRTest extends TestCase
 
 	public function testCustomExecutablePath()
 	{
-		$expected = '"/custom/path/to/tesseract" "image.png" tmpfile';
+		$expected = '"/custom/path/to/tesseract" "image.png" "tmpfile"';
 		$actual = $this->tess->executable('/custom/path/to/tesseract')->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testDefiningOptions()
 	{
-		$expected = '"tesseract" "image.png" tmpfile -l eng hocr';
+		$expected = '"tesseract" "image.png" "tmpfile" -l eng hocr';
 		$actual = $this->tess->lang('eng')->format('hocr')->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testWhitelistSingleStringArgument()
 	{
-		$expected = '"tesseract" "image.png" tmpfile -c "tessedit_char_whitelist=abcdefghij"';
+		$expected = '"tesseract" "image.png" "tmpfile" -c "tessedit_char_whitelist=abcdefghij"';
 		$actual = $this->tess->whitelist('abcdefghij')->command;
 		$this->assertEquals("$expected", $actual);
 	}
 
 	public function testWhitelistMultipleStringArguments()
 	{
-		$expected = '"tesseract" "image.png" tmpfile -c "tessedit_char_whitelist=abcdefghij"';
+		$expected = '"tesseract" "image.png" "tmpfile" -c "tessedit_char_whitelist=abcdefghij"';
 		$actual = $this->tess->whitelist('ab', 'cd', 'ef', 'gh', 'ij')->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testWhitelistSingleArrayArgument()
 	{
-		$expected = '"tesseract" "image.png" tmpfile -c "tessedit_char_whitelist=abcdefghij"';
+		$expected = '"tesseract" "image.png" "tmpfile" -c "tessedit_char_whitelist=abcdefghij"';
 		$actual = $this->tess->whitelist(range('a', 'j'))->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testWhitelistMultipleArrayArguments()
 	{
-		$expected = '"tesseract" "image.png" tmpfile -c "tessedit_char_whitelist=abcdefghij"';
+		$expected = '"tesseract" "image.png" "tmpfile" -c "tessedit_char_whitelist=abcdefghij"';
 		$actual = $this->tess->whitelist(range('a', 'e'), range('f', 'j'))->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testWhitelistMixedArguments()
 	{
-		$expected = '"tesseract" "image.png" tmpfile -c "tessedit_char_whitelist=0123456789abcdefghij"';
+		$expected = '"tesseract" "image.png" "tmpfile" -c "tessedit_char_whitelist=0123456789abcdefghij"';
 		$actual = $this->tess->whitelist(range(0, 9), 'abcd', range('e', 'j'))->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testDefiningConfigPairs()
 	{
-		$expected = '"tesseract" "image.png" tmpfile '
+		$expected = '"tesseract" "image.png" "tmpfile" '
 			.'-c "load_system_dawg=F" '
 			.'-c "tessedit_create_pdf=1"';
 		$actual = $this->tess->loadSystemDawg('F')->tesseditCreatePdf(1)->command;
@@ -103,7 +103,7 @@ class TesseractOCRTest extends TestCase
 
 	public function testDefiningConfigFile()
 	{
-		$expected = '"tesseract" "image.png" tmpfile tsv';
+		$expected = '"tesseract" "image.png" "tmpfile" tsv';
 		$actual = $this->tess->configFile('tsv')->command;
 		$this->assertEquals("$expected", "$actual");
 	}
@@ -111,49 +111,49 @@ class TesseractOCRTest extends TestCase
 	// @deprecated
 	public function testDefiningFormat()
 	{
-		$expected = '"tesseract" "image.png" tmpfile tsv';
+		$expected = '"tesseract" "image.png" "tmpfile" tsv';
 		$actual = $this->tess->format('tsv')->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testDigits()
 	{
-		$expected = '"tesseract" "image.png" tmpfile digits';
+		$expected = '"tesseract" "image.png" "tmpfile" digits';
 		$actual = $this->tess->digits()->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testHocr()
 	{
-		$expected = '"tesseract" "image.png" tmpfile hocr';
+		$expected = '"tesseract" "image.png" "tmpfile" hocr';
 		$actual = $this->tess->hocr()->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testPdf()
 	{
-		$expected = '"tesseract" "image.png" tmpfile pdf';
+		$expected = '"tesseract" "image.png" "tmpfile" pdf';
 		$actual = $this->tess->pdf()->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testQuiet()
 	{
-		$expected = '"tesseract" "image.png" tmpfile quiet';
+		$expected = '"tesseract" "image.png" "tmpfile" quiet';
 		$actual = $this->tess->quiet()->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testTsv()
 	{
-		$expected = '"tesseract" "image.png" tmpfile tsv';
+		$expected = '"tesseract" "image.png" "tmpfile" tsv';
 		$actual = $this->tess->tsv()->command;
 		$this->assertEquals("$expected", "$actual");
 	}
 
 	public function testTxt()
 	{
-		$expected = '"tesseract" "image.png" tmpfile txt';
+		$expected = '"tesseract" "image.png" "tmpfile" txt';
 		$actual = $this->tess->txt()->command;
 		$this->assertEquals("$expected", "$actual");
 	}
@@ -171,7 +171,7 @@ class TesseractOCRTest extends TestCase
 
 	public function testThreadLimit()
 	{
-		$expected = 'OMP_THREAD_LIMIT=4 "tesseract" "image.png" tmpfile';
+		$expected = 'OMP_THREAD_LIMIT=4 "tesseract" "image.png" "tmpfile"';
 		$actual = $this->tess->threadLimit(4)->command;
 		$this->assertEquals("$expected", "$actual");
 	}

--- a/tests/Unit/TestableCommand.php
+++ b/tests/Unit/TestableCommand.php
@@ -6,7 +6,7 @@ class TestableCommand extends Command
 {
 	public function __construct($image=null, $version='3.05')
 	{
-		parent::__construct($image, 'tmpfile');
+		parent::__construct($image, '"tmpfile"');
 		$this->version = $version;
 	}
 


### PR DESCRIPTION
### Description

While attempting OCR on my local machine (xampp on win10) :
Running tesseract directly in the terminal resulted in no issues. 
However when attempting to use the library the command failed and resulted in the following error:

```
Generated command:
"tesseract" "C:\\xampp\\htdocs\\ocr_debug\\text.jpg" C:\Users\FirstName LastName\AppData\Local\Temp\ocr1D0E.tmp

Returned message:
Tesseract Open Source OCR Engine v3.05.00dev with Leptonica
read_params_file: Can't open LastName\AppData\Local\Temp\ocr1D0E.tmp in C:\xampp\htdocs\ocr_debug\vendor\thiagoalessio\tesseract_ocr\src\FriendlyErrors.php:63
Stack trace:
#0 C:\xampp\htdocs\ocr_debug\vendor\thiagoalessio\tesseract_ocr\src\TesseractOCR.php(24): thiagoalessio\TesseractOCR\FriendlyErrors::checkCommandExecution(Object(thiagoalessio\TesseractOCR\Command), Array)
#1 C:\xampp\htdocs\ocr_debug\index.php(28): thiagoalessio\TesseractOCR\TesseractOCR->run()
#2 {main} thrown in C:\xampp\htdocs\ocr_debug\vendor\thiagoalessio\tesseract_ocr\src\FriendlyErrors.php on line 63
```

Notice because of the space between "FirstName" and "LastName":
`C:\Users\FirstName LastName\AppData\Local\Temp\ocr1D0E.tmp`
was passed and tesseract assumed
`LastName\AppData\Local\Temp\ocr1D0E.tmp`
as a 4th parameter


### Debugging


In Command.php:getTempDir temp returns from `sys_get_temp_dir()` like so: 
`C:\Users\FIRSTNAME~1\AppData\Local\Temp`
Which is perfectly fine and contains no spaces

In **Command.php:getOutputFile** temp returns from `tempnam(sys_get_temp_dir(), 'ocr')` like so:
`C:\Users\FirstName LastName\AppData\Local\Temp\ocr1CA0.tmp`
**Not the expected:**
`C:\Users\FIRSTNAME~1\AppData\Local\Temp\ocr1D0E.tmp`

A problem because since the directory could have a space, command: 
`"tesseract" "C:\\xampp\\htdocs\\ocr_debug\\text.jpg" C:\Users\FirstName LastName\AppData\Local\Temp\ocr1D0E.tmp`
is attempted


### Fix

I wrapped `$this->getOutputFile(false)` with `self::escape( ... )`
**The correct command:**
`"tesseract" "C:\\xampp\\htdocs\\edgefinder\\text.jpg" "C:\\Users\\FirstName LastName\\AppData\\Local\\Temp\\ocr1D0E.tmp"`

-Bonus Points: I believe I made the correct changes to the tests to accommodate the change
+Apparently I have no idea how to write tests

### Related Issues

I forked the repo and made the changes to the forked files. It appears that you've made changes since the last version was published so (since I havent made a PR before and don't understand the merging) I included the changes you've made since... Hoping that makes the merge easier?