### PR TITLE
Fixed version comparison when current version has "v" prefix.

### DIFF
--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -85,6 +85,10 @@ class FriendlyErrors
 	public static function checkTesseractVersion($expected, $action, $command)
 	{
 		$actual = $command->getTesseractVersion();
+
+		if ($actual[0] === 'v')
+			$actual = substr($actual, 1);
+
 		if (version_compare($actual, $expected, ">=")) return;
 
 		$msg = array();
@@ -97,7 +101,7 @@ class FriendlyErrors
 
 		throw new FeatureNotAvailableException($msg);
 	}
-	
+
 	public static function checkWritePermissions($path)
 	{
 		if (!is_dir(dirname($path))) mkdir(dirname($path));


### PR DESCRIPTION
When library requests version of tesseract executable on Windows it may receive version with "v" prefix. For example "v5.0.0-alpha.20191030".

![image](https://user-images.githubusercontent.com/25498109/71086101-cfabd500-21ba-11ea-9259-0b6535c8f834.png)

PHP function version_compare() returns incorrect result because of prefix.

![image](https://user-images.githubusercontent.com/25498109/71085987-865b8580-21ba-11ea-96a2-9749d2506506.png)

In this PR i just remove "v" prefix from version number if it found.
