### PR TITLE
Fix for issue with creating empty temp file when withoutTempFiles() mode

### DIFF
--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -49,14 +49,13 @@ class FriendlyErrors
 	public static function checkCommandExecution($command, $stdout, $stderr)
 	{
 		if ($command->useFileAsOutput) {
-			$file = $command->getOutputFile();
-			$executionCheckOk = (file_exists($file) && filesize($file) > 0);
-		}
-		else {
-			$executionCheckOk = (true == $stdout);
+		    $file = $command->getOutputFile();
+		    if (file_exists($file) && filesize($file) > 0)  return;
 		}
 
-		if ($executionCheckOk) return;
+		if (!$command->useFileAsOutput && $stdout) {
+			return;
+		}
 
 		$msg = array();
 		$msg[] = 'Error! The command did not produce any output.';

--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -48,10 +48,15 @@ class FriendlyErrors
 
 	public static function checkCommandExecution($command, $stdout, $stderr)
 	{
-		$file = $command->getOutputFile();
+		if ($command->useFileAsOutput) {
+			$file = $command->getOutputFile();
+			$executionCheckOk = (file_exists($file) && filesize($file) > 0);
+		}
+		else {
+			$executionCheckOk = (true == $stdout);
+		}
 
-		if (($command->useFileAsOutput && file_exists($file) && filesize($file) > 0) ||
-			(!$command->useFileAsOutput && $stdout)) return;
+		if ($executionCheckOk) return;
 
 		$msg = array();
 		$msg[] = 'Error! The command did not produce any output.';

--- a/tests/EndToEnd/ReadmeExamples.php
+++ b/tests/EndToEnd/ReadmeExamples.php
@@ -74,10 +74,16 @@ class ReadmeExamples extends TestCase
 
 		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(false)));
 		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(true)));
+	}
+
+	public function testTemporaryFilesAreNotCreated()
+    {
+        // Cannot read from stdin in version 3.02
+		if ($this->isVersion302()) $this->skip();
 
 		$ocr = new TesseractOCR("{$this->imagesDir}/text.png");
 		$ocr->withoutTempFiles();
-		$ocr->run();
+        $ocr->run();
 
 		$reflectionProperty = (new ReflectionObject($ocr->command))->getProperty('outputFile');
 		$reflectionProperty->setAccessible(true);
@@ -85,7 +91,7 @@ class ReadmeExamples extends TestCase
 		echo $outputFileValue;
 
 		$this->assertEquals(null, $outputFileValue);
-	}
+    }
 
 	public function testWithoutInputFile()
 	{

--- a/tests/EndToEnd/ReadmeExamples.php
+++ b/tests/EndToEnd/ReadmeExamples.php
@@ -2,6 +2,7 @@
 
 use thiagoalessio\TesseractOCR\Tests\Common\TestCase;
 use thiagoalessio\TesseractOCR\TesseractOCR;
+use ReflectionObject;
 
 class ReadmeExamples extends TestCase
 {
@@ -73,6 +74,17 @@ class ReadmeExamples extends TestCase
 
 		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(false)));
 		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(true)));
+
+		$ocr = new TesseractOCR("{$this->imagesDir}/text.png");
+		$ocr->withoutTempFiles();
+		$ocr->run();
+
+		$reflectionProperty = (new ReflectionObject($ocr->command))->getProperty('outputFile');
+		$reflectionProperty->setAccessible(true);
+		$outputFileValue = $reflectionProperty->getValue($ocr->command);
+		echo $outputFileValue;
+
+		$this->assertEquals(null, $outputFileValue);
 	}
 
 	public function testWithoutInputFile()


### PR DESCRIPTION
### Description
Fix for issue when TesseractOCR is executed with option withoutTempFiles()
but temporary output file is created while getOuptutFile() is called
inside FirendlyErrors::checkCommandExecution() during checking a source
(file or stdout) for valid result output.
See [source code](https://github.com/thiagoalessio/tesseract-ocr-for-php/blob/master/src/FriendlyErrors.php#L51).

This issue can cause an occurance of many undeleted empty ocr* files in
temp directory and finally can lead to a lack of inodes.

Old behaviour: empty ocr* file is created on each launch of
TesseractOCR::withoutTempFiles() and TesseractOcr::run().

New behaviour: empty ocr* file is not created in this case.
