### PR TITLE
Fix for issue with creating empty temp file when withoutTempFiles() mode

### DIFF
--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -48,10 +48,14 @@ class FriendlyErrors
 
 	public static function checkCommandExecution($command, $stdout, $stderr)
 	{
-		$file = $command->getOutputFile();
+		if ($command->useFileAsOutput) {
+		    $file = $command->getOutputFile();
+		    if (file_exists($file) && filesize($file) > 0)  return;
+		}
 
-		if (($command->useFileAsOutput && file_exists($file) && filesize($file) > 0) ||
-			(!$command->useFileAsOutput && $stdout)) return;
+		if (!$command->useFileAsOutput && $stdout) {
+			return;
+		}
 
 		$msg = array();
 		$msg[] = 'Error! The command did not produce any output.';

--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -1,10 +1,12 @@
 <?php namespace thiagoalessio\TesseractOCR;
 
-class ImageNotFoundException extends \Exception {}
-class TesseractNotFoundException extends \Exception {}
-class UnsuccessfulCommandException extends \Exception {}
-class FeatureNotAvailableException extends \Exception {}
-class NoWritePermissionsForOutputFile extends \Exception {}
+abstract class TesseractOcrException extends \Exception {}
+
+class ImageNotFoundException extends TesseractOcrException {}
+class TesseractNotFoundException extends TesseractOcrException {}
+class UnsuccessfulCommandException extends TesseractOcrException {}
+class FeatureNotAvailableException extends TesseractOcrException {}
+class NoWritePermissionsForOutputFile extends TesseractOcrException {}
 
 class FriendlyErrors
 {

--- a/tests/EndToEnd/ReadmeExamples.php
+++ b/tests/EndToEnd/ReadmeExamples.php
@@ -2,6 +2,7 @@
 
 use thiagoalessio\TesseractOCR\Tests\Common\TestCase;
 use thiagoalessio\TesseractOCR\TesseractOCR;
+use ReflectionObject;
 
 class ReadmeExamples extends TestCase
 {
@@ -73,6 +74,23 @@ class ReadmeExamples extends TestCase
 
 		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(false)));
 		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(true)));
+	}
+
+	public function testTemporaryFilesAreNotCreated()
+	{
+		// Cannot read from stdin in version 3.02
+		if ($this->isVersion302()) $this->skip();
+
+		$ocr = new TesseractOCR("{$this->imagesDir}/text.png");
+		$ocr->withoutTempFiles();
+		$ocr->run();
+
+		$reflectionProperty = (new ReflectionObject($ocr->command))->getProperty('outputFile');
+		$reflectionProperty->setAccessible(true);
+		$outputFileValue = $reflectionProperty->getValue($ocr->command);
+		echo $outputFileValue;
+
+		$this->assertEquals(null, $outputFileValue);
 	}
 
 	public function testWithoutInputFile()

--- a/tests/EndToEnd/ReadmeExamples.php
+++ b/tests/EndToEnd/ReadmeExamples.php
@@ -1,5 +1,6 @@
 <?php namespace thiagoalessio\TesseractOCR\Tests\EndToEnd;
 
+use thiagoalessio\TesseractOCR\TesseractOcrException;
 use thiagoalessio\TesseractOCR\Tests\Common\TestCase;
 use thiagoalessio\TesseractOCR\TesseractOCR;
 use ReflectionObject;
@@ -88,9 +89,23 @@ class ReadmeExamples extends TestCase
 		$reflectionProperty = (new ReflectionObject($ocr->command))->getProperty('outputFile');
 		$reflectionProperty->setAccessible(true);
 		$outputFileValue = $reflectionProperty->getValue($ocr->command);
-		echo $outputFileValue;
 
 		$this->assertEquals(null, $outputFileValue);
+	}
+
+	public function testTemporaryFilesAreDeletedInCaseOfException()
+	{
+
+		try {
+			$ocr = new TesseractOCR("{$this->imagesDir}/not-an-image.txt");
+			$ocr->run();
+		}
+		catch (TesseractOcrException $e) {
+
+		}
+
+		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(false)));
+		$this->assertEquals(false, file_exists($ocr->command->getOutputFile(true)));
 	}
 
 	public function testWithoutInputFile()


### PR DESCRIPTION
### Description

Fix for issue when TesseractOCR is executed with option withoutTempFiles()
but temporary output file is created while getOuptutFile() is called
inside FirendlyErrors::checkCommandExecution() during checking a source
(file or stdout) for valid result output.
See [source code](https://github.com/thiagoalessio/tesseract-ocr-for-php/blob/master/src/FriendlyErrors.php#L51).

This issue can cause an occurance of many undeleted empty ocr* files in
temp directory and finally can lead to a lack of inodes.

Old behaviour: empty ocr* file is created on each launch of
TesseractOCR::withoutTempFiles() and TesseractOcr::run().

New behaviour: empty ocr* file is not created in this case.
