### PR TITLE
Allow PHP 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
     
   php-8.0:
     docker:
-      - image: php:8.0-rc
+      - image: php:8.0
     steps: *unit_tests
 
   tess-3.02:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
     
   php-8.0:
     docker:
-      - image: php:8.0.0
+      - image: php:8.0
     steps: *unit_tests
 
   tess-3.02:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
     
   php-8.0:
     docker:
-      - image: php:8.0
+      - image: php:8.0.0
     steps: *unit_tests
 
   tess-3.02:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,11 @@ jobs:
     docker:
       - image: php:7.4
     steps: *unit_tests
+    
+  php-8.0:
+    docker:
+      - image: php:8.0-rc
+    steps: *unit_tests
 
   tess-3.02:
     docker:
@@ -88,6 +93,7 @@ php_jobs: &php_jobs
   - php-7.2
   - php-7.3
   - php-7.4
+  - php-8.0
 
 workflows:
   version: 2
@@ -100,6 +106,7 @@ workflows:
       - php-7.2
       - php-7.3
       - php-7.4
+      - php-8.0
       - tess-3.02:
           requires: *php_jobs
       - tess-3.03:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"php": "^5.4 || ^7.0 || ^8.0"
 	},
 	"require-dev": {
-		"phpunit/php-code-coverage": "^2.2.4",
+		"phpunit/php-code-coverage": "^2.2.4 || ^9.0.0",
 		"codacy/coverage": "dev-master"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"source": "https://github.com/thiagoalessio/tesseract-ocr-for-php"
 	},
 	"require": {
-		"php": "^5.4 || ^7.0"
+		"php": "^5.4 || ^7.0 || ^8.0"
 	},
 	"require-dev": {
 		"phpunit/php-code-coverage": "^2.2.4",


### PR DESCRIPTION
### Description

Package can't be installed on PHP 8.0. 

### Related Issues

None.

CC: @thiagoalessio 

We must wait for newest https://github.com/docker-library/php/pull/1090 image.
