### PR TITLE
PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"source": "https://github.com/thiagoalessio/tesseract-ocr-for-php"
 	},
 	"require": {
-		"php": "^5.4 || ^7.0"
+		"php": "^5.4 || ^7.0 || ^8.0"
 	},
 	"require-dev": {
 		"phpunit/php-code-coverage": "^2.2.4",


### PR DESCRIPTION
Makes composer compatible with PHP 8.

I haven't been able to make tests compatible with PHP 8, all the way down to PHP 5.4.

With PHP 8, I get:

> Uncaught Error: Undefined constant "XDEBUG_CC_UNUSED"

probably because I use Xdebug 3.

I tried upgrading `phpunit/php-code-coverage`, but it wasn't compatible with PHP 5, and required changes to your tests.

Suggestions:

- Just mark composer.json as compatible with PHP ^8.0 for now (your library does work with PHP 8)
- Consider moving tests to PHPUnit, it will make the version changes easier
- Consider narrowing a bit your supported PHP versions; you can still support PHP 5.4 in this version, but then create version 3.0 with PHP >= 7.2 support, for example; this way, people on outdated (long dead, actually!) PHP versions can still use the previous version of your library; if they want all the bells and whistles, they'll have to upgrade PHP. And if you do happen to fix a very nasty bug, you can still backport the fix to a 2.x branch if you wish. A single branch for all PHP versions, together with compatible dependencies & test suite is a hell of a lot of work, if ever possible, and I don't think it's worth it.