### PR TITLE
Respect PSR-4 file structure

### DIFF
--- a/src/FeatureNotAvailableException.php
+++ b/src/FeatureNotAvailableException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace thiagoalessio\TesseractOCR;
+
+class FeatureNotAvailableException extends TesseractOcrException
+{
+}

--- a/src/FriendlyErrors.php
+++ b/src/FriendlyErrors.php
@@ -1,13 +1,5 @@
 <?php namespace thiagoalessio\TesseractOCR;
 
-abstract class TesseractOcrException extends \Exception {}
-
-class ImageNotFoundException extends TesseractOcrException {}
-class TesseractNotFoundException extends TesseractOcrException {}
-class UnsuccessfulCommandException extends TesseractOcrException {}
-class FeatureNotAvailableException extends TesseractOcrException {}
-class NoWritePermissionsForOutputFile extends TesseractOcrException {}
-
 class FriendlyErrors
 {
 	public static function checkImagePath($image)

--- a/src/ImageNotFoundException.php
+++ b/src/ImageNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace thiagoalessio\TesseractOCR;
+
+class ImageNotFoundException extends TesseractOcrException
+{
+}

--- a/src/NoWritePermissionsForOutputFile.php
+++ b/src/NoWritePermissionsForOutputFile.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace thiagoalessio\TesseractOCR;
+
+class NoWritePermissionsForOutputFile extends TesseractOcrException
+{
+}

--- a/src/TesseractNotFoundException.php
+++ b/src/TesseractNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace thiagoalessio\TesseractOCR;
+
+class TesseractNotFoundException extends TesseractOcrException
+{
+}

--- a/src/TesseractOcrException.php
+++ b/src/TesseractOcrException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace thiagoalessio\TesseractOCR;
+
+abstract class TesseractOcrException extends \Exception
+{
+}

--- a/src/UnsuccessfulCommandException.php
+++ b/src/UnsuccessfulCommandException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace thiagoalessio\TesseractOCR;
+
+class UnsuccessfulCommandException extends TesseractOcrException
+{
+}


### PR DESCRIPTION
### Description

The exception classes of this project do not respect [PSR-4](https://www.php-fig.org/psr/psr-4/), which assumes that every class lies in its own file, matching the class name.

The issue might not be obvious at first glance, but the fact is, you cannot use one of these exceptions if you haven't used the `TesseractOCR` class first, that triggers autoloading of `FriendlyErrors`, that in turns declares the exception classes.

I know, you're not supposed to actually throw these exceptions yourself, but the lack of PSR-4 compliance triggers subtle bugs, like one that I just declared with Psalm: https://github.com/vimeo/psalm/issues/5188. Psalm says that the class does not exist, because it relies on being able to autoload it on its own.

### Fix

I fixed the issue in a BC manner by just moving each exception class to its own file. This is the only way to make the change backwards compatible.

### Future scope

If you wish to keep the main namespace clean, I'd suggest you move the exceptions to an `Exception` sub-namespace in the next major version (3.0.0).

Oh, and even though I don't think it's covered by any official standard, it's a de-facto standard to use capitalized namespaces, so I'd suggest to take the opportunity of the next major version to rename the root namespace to `ThiagoAlessio`, for example! :+1: 

### Related Issues

https://github.com/vimeo/psalm/issues/5188

