### PR TITLE
Add timeout to calling tesseract

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -6,9 +6,11 @@ class Process {
     private $stdout;
     private $stderr;
     private $handle;
+    private $startTime;
 
     public function __construct($command)
     {
+        $this->startTime = microtime(true);
         $streamDescriptors = [
             array("pipe", "r"),
             array("pipe", "w"),
@@ -35,11 +37,11 @@ class Process {
     }
 
 
-    public function wait()
+    public function wait($timeout = 0)
     {
         $running = true;
         $data = ["out" => "", "err" => ""];
-        while ($running === true)
+        while (($running === true) && !$this->hasTimedOut($timeout))
         {
             $data["out"] .= fread($this->stdout, 8192);
             $data["err"] .= fread($this->stderr, 8192);
@@ -62,6 +64,11 @@ class Process {
         $this->closeStream($this->stdin);
     }
 
+    private function hasTimedOut($timeout)
+    {
+        return (($timeout > 0) &&  ($this->startTime + $timeout < microtime(true)));    
+    }
+    
     private function closeStream(&$stream)
     {
         if ($stream !== NULL)

--- a/src/TesseractOCR.php
+++ b/src/TesseractOCR.php
@@ -15,7 +15,7 @@ class TesseractOCR
 		$this->image("$image");
 	}
 
-	public function run()
+	public function run($timeout = 0)
 	{
 		try {
 			if ($this->outputFile !== null) {
@@ -34,7 +34,7 @@ class TesseractOCR
 				$process->write($this->command->image, $this->command->imageSize);
 				$process->closeStdin();
 			}
-			$output = $process->wait();
+			$output = $process->wait($timeout);
 
 			FriendlyErrors::checkCommandExecution($this->command, $output["out"], $output["err"]);
 		}


### PR DESCRIPTION
This PR introduces a timeout to the execution of tesseract to prevent endless execution of a stalled tesseract. 