### PR TITLE
Sleep for 1 ms while waiting to yield CPU

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -47,6 +47,9 @@ class Process {
             $data["err"] .= fread($this->stderr, 8192);
             $procInfo = proc_get_status($this->handle);
             $running = $procInfo["running"];
+            if ($running) {
+                usleep(1000); // Sleep 1ms to yield CPU time
+            }
         }
         return $data;
     }


### PR DESCRIPTION
### Description

When waiting for tesseract the CPU of the PHP process runs at 100% on a single core. This change introduces a 1ms sleep to yield the cpu for other processes. 
